### PR TITLE
added: Solarized Themes

### DIFF
--- a/qss/SolarizedDark.qss
+++ b/qss/SolarizedDark.qss
@@ -1,0 +1,262 @@
+/* Author : Blue DeviL // SCT */
+QWidget
+{
+    color: #fdf6e3;
+    background-color: #002b36;
+}
+
+QWidget:disabled
+{
+    color: #657b83;
+    background-color: #073642;
+}
+
+QWidget:item:hover
+{
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #ca0619);
+    color: #fdf6e3;
+}
+
+QAbstractItemView
+{
+    background-color: #32555e;
+}
+
+QCheckBox::indicator:checked
+{
+    color: #b1b1b1;
+    background-color: #d7801a;
+    border: 1px solid #b1b1b1;
+}
+
+QCheckBox::indicator:unchecked
+{
+    color: #b1b1b1;
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #25464e, stop: 0 #32555e, stop: 1 #5d5d5d);
+    border: 1px solid #b1b1b1;
+}
+
+QRadioButton::indicator:checked
+{
+    color: #b1b1b1;
+    background-color: #d7801a;
+    border: 1px solid #b1b1b1;
+    border-radius: 6px;
+}
+
+QRadioButton::indicator:unchecked
+{
+    color: #b1b1b1;
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #25464e, stop: 0 #32555e, stop: 1 #5d5d5d);
+    border: 1px solid #b1b1b1;
+    border-radius: 6px;
+}
+
+QTableView
+{
+    gridline-color: #32555e;
+}
+
+QTreeView::item 
+{
+    color: #fdf6e3;
+}
+
+QLineEdit
+{
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #25464e, stop: 0 #32555e, stop: 1 #002b36);
+    padding: 1px;
+    border-style: solid;
+    border: 1px solid #1e1e1e;
+}
+
+QLineEdit:hover
+{
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #ca0619);
+    color: #000000;
+}
+
+QPushButton
+{
+    color: #fdf6e3;
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #002b3b, stop: 0.1 #002838, stop: 0.5 #073545, stop: 0.9 #073141, stop: 1 #072f3f);
+    border-width: 1px;
+    border-color: #1e1e1e;
+}
+
+QPushButton:disabled
+{
+    color: #3c5c5c;
+    background-color: grey;
+}
+
+QProgressBar
+{
+    border: 2px solid grey;
+    text-align: center;
+}
+
+QProgressBar::chunk
+{
+    background-color: #d7801a;
+    width: 2.15px;
+}
+
+QTabBar::tab 
+{
+    color: #b1b1b1;
+    border: 1px solid #444;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    border-bottom-style: none;
+    background-color: #002b36;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 3px;
+    padding-bottom: 2px;
+    margin-bottom: -1px;
+    /*margin-right: -1px;*/
+}
+
+QScrollBar:horizontal 
+{
+    border: 1px solid #222222;
+    background: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0.0 #121212, stop: 0.2 #282828, stop: 1 #484848);
+    height: 7px;
+    margin: 0px 16px 0 16px;
+}
+
+QScrollBar::handle:horizontal
+{
+    background: QLinearGradient( x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #ffa02f, stop: 0.5 #d7801a, stop: 1 #ffa02f);
+    min-height: 20px;
+    border-radius: 2px;
+}
+
+QScrollBar::add-line:horizontal 
+{
+    border: 1px solid #1b1b19;
+    border-radius: 2px;
+    background: QLinearGradient( x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #ffa02f, stop: 1 #d7801a);
+    width: 14px;
+    subcontrol-position: right;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:horizontal 
+{
+    border: 1px solid #1b1b19;
+    border-radius: 2px;
+    background: QLinearGradient( x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #ffa02f, stop: 1 #d7801a);
+    width: 14px;
+    subcontrol-position: left;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::right-arrow:horizontal, QScrollBar::left-arrow:horizontal
+{
+    border: 1px solid black;
+    width: 1px;
+    height: 1px;
+    background: white;
+}
+
+QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal
+{
+    background: none;
+}
+
+QScrollBar:vertical
+{
+    background: QLinearGradient( x1: 0, y1: 0, x2: 1, y2: 0, stop: 0.0 #121212, stop: 0.2 #282828, stop: 1 #484848);
+    width: 7px;
+    margin: 16px 0 16px 0;
+    border: 1px solid #222222;
+}
+
+QScrollBar::handle:vertical
+{
+    background: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 0.5 #d7801a, stop: 1 #ffa02f);
+    min-height: 20px;
+    border-radius: 2px;
+}
+
+QScrollBar::add-line:vertical
+{
+    border: 1px solid #1b1b19;
+    border-radius: 2px;
+    background: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #d7801a);
+    height: 14px;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:vertical
+{
+    border: 1px solid #1b1b19;
+    border-radius: 2px;
+    background: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #d7801a, stop: 1 #ffa02f);
+    height: 14px;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical
+{
+    border: 1px solid black;
+    width: 1px;
+    height: 1px;
+    background: white;
+}
+
+QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical
+{
+    background: none;
+}
+
+QTextEdit
+{
+    background-color:#32555e;
+    color:#fdf6e3;
+    border: native;
+}
+
+QPlainTextEdit
+{
+    background-color:#32555e;
+    color:#fdf6e3;
+    border: native;
+}
+
+QHeaderView::section
+{
+    background-color: QLinearGradient(x1:0, y1:0, x2:0, y2:1, stop:0 #002b3b, stop: 0.5 #002838, stop: 0.6 #073545, stop:1 #073141);
+    color: white;
+    padding-left: 4px;
+    border: 1px solid #6c6c6c;
+}
+
+QMenu
+{
+    border: 1px solid #000;
+}
+
+QMenu::item:selected
+{
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #ca0619);
+    color: #002b36;
+}
+
+XHexView
+{
+    background-color:#32555e;
+    color: #fdf6e3;
+    border: native;
+}
+
+XDisasmView
+{
+    background-color:#073642;
+    color: #fdf6e3;
+    border: native;
+}

--- a/qss/SolarizedLight.qss
+++ b/qss/SolarizedLight.qss
@@ -1,0 +1,249 @@
+/* Author : Blue DeviL // SCT */
+QWidget
+{
+    color: #002b36;
+    background-color: #eee8d5;
+}
+
+QWidget:disabled
+{
+    color: #657b83;
+    background-color: #eee8d5;
+}
+
+QWidget:item:hover
+{
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #ca0619);
+    color: #002b36;
+}
+
+QAbstractItemView
+{
+    background-color: #eee8d5;
+}
+
+QCheckBox::indicator:checked
+{
+    color: #b1b1b1;
+    background-color: #d7801a;
+    border: 1px solid #b1b1b1;
+}
+
+QCheckBox::indicator:unchecked
+{
+    color: #b1b1b1;
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #4d4d4d, stop: 0 #93a1a1, stop: 1 #5d5d5d);
+    border: 1px solid #b1b1b1;
+}
+
+QRadioButton::indicator:checked
+{
+    color: #b1b1b1;
+    background-color: #d7801a;
+    border: 1px solid #b1b1b1;
+    border-radius: 6px;
+}
+
+QRadioButton::indicator:unchecked
+{
+    color: #b1b1b1;
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #4d4d4d, stop: 0 #93a1a1, stop: 1 #5d5d5d);
+    border: 1px solid #b1b1b1;
+    border-radius: 6px;
+}
+
+QTableView
+{
+    gridline-color: #93a1a1;
+}
+
+QTreeView::item 
+{
+    color: #002b36;
+}
+
+QLineEdit
+{
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #fdf6e3, stop: 0.5 #eee8d5, stop: 1 #cfc9b8);
+    padding: 1px;
+    border-style: solid;
+    border: 1px solid #1e1e1e;
+}
+
+QLineEdit:hover
+{
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #ca0619);
+    color: #000000;
+}
+
+QPushButton
+{
+    color: #002b36;
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #fdf6e3, stop: 0.1 #fdf6e3, stop: 0.5 #eee8d5, stop: 0.9 #eee8d5, stop: 1 #93a1a1);
+    border-width: 1px;
+    border-color: #1e1e1e;
+}
+
+QPushButton:disabled
+{
+    color: #565656;
+    background-color: #918e81;
+}
+
+QProgressBar
+{
+    border: 2px solid grey;
+    text-align: center;
+}
+
+QProgressBar::chunk
+{
+    background-color: #d7801a;
+    width: 2.15px;
+}
+
+QTabBar::tab 
+{
+    color: #002b36;
+    border: 1px solid #444444;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    border-bottom-style: none;
+    /*background-color: #fdf6e3;*/
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 3px;
+    padding-bottom: 2px;
+    margin-bottom: -1px;
+    /*margin-right: -1px;*/
+}
+
+QScrollBar:horizontal 
+{
+    border: 1px solid #222222;
+    background: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0.0 #121212, stop: 0.2 #282828, stop: 1 #484848);
+    height: 7px;
+    margin: 0px 16px 0 16px;
+}
+
+QScrollBar::handle:horizontal
+{
+    background: QLinearGradient( x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #ffa02f, stop: 0.5 #d7801a, stop: 1 #ffa02f);
+    min-height: 20px;
+    border-radius: 2px;
+}
+
+QScrollBar::add-line:horizontal 
+{
+    border: 1px solid #1b1b19;
+    border-radius: 2px;
+    background: QLinearGradient( x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #ffa02f, stop: 1 #d7801a);
+    width: 14px;
+    subcontrol-position: right;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:horizontal 
+{
+    border: 1px solid #1b1b19;
+    border-radius: 2px;
+    background: QLinearGradient( x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #ffa02f, stop: 1 #d7801a);
+    width: 14px;
+    subcontrol-position: left;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::right-arrow:horizontal, QScrollBar::left-arrow:horizontal
+{
+    border: 1px solid black;
+    width: 1px;
+    height: 1px;
+    background: white;
+}
+
+QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal
+{
+    background: none;
+}
+
+QScrollBar:vertical
+{
+    background: QLinearGradient( x1: 0, y1: 0, x2: 1, y2: 0, stop: 0.0 #121212, stop: 0.2 #282828, stop: 1 #484848);
+    width: 7px;
+    margin: 16px 0 16px 0;
+    border: 1px solid #222222;
+}
+
+QScrollBar::handle:vertical
+{
+    background: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 0.5 #d7801a, stop: 1 #ffa02f);
+    min-height: 20px;
+    border-radius: 2px;
+}
+
+QScrollBar::add-line:vertical
+{
+    border: 1px solid #1b1b19;
+    border-radius: 2px;
+    background: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #d7801a);
+    height: 14px;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:vertical
+{
+    border: 1px solid #1b1b19;
+    border-radius: 2px;
+    background: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #d7801a, stop: 1 #ffa02f);
+    height: 14px;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical
+{
+    border: 1px solid black;
+    width: 1px;
+    height: 1px;
+    background: white;
+}
+
+QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical
+{
+    background: none;
+}
+
+QTextEdit
+{
+    background-color:#fdf6e3;
+    color:#002b3b;
+    border: native;
+}
+
+QPlainTextEdit
+{
+    background-color:#fdf6e3;
+    color:#002b3b;
+    border: native;
+}
+
+QHeaderView::section
+{
+    background-color: QLinearGradient(x1:0, y1:0, x2:0, y2:1, stop:0 #616161, stop: 0.5 #505050, stop: 0.6 #434343, stop:1 #656565);
+    color: white;
+    padding-left: 4px;
+    border: 1px solid #6c6c6c;
+}
+
+QMenu
+{
+    border: 1px solid #000;
+}
+
+QMenu::item:selected
+{
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #ca0619);
+    color: #002b36;
+}
+


### PR DESCRIPTION
Hello @horsicq 

Here I have created Solarized Dark and Solarized Light themes for
Detect It Easy. They are ok and working. But I want to make them perfect.
I have some issues that I cannot solve:

**Hex output**:

I have realized that you have created a widget called **XHexView** and
I have successfully set the backgound color of hex views by adding those
lines to qss:

```css
XHexView
{
    background-color:#32555e;
    color: #fdf6e3;
    border: native;
}
```

Are there any sub controls or sub-functions for this control?
(like **hover** or **pressed**)

**Hex Color**?

I cannot changed the color of hex output? How can I change the color of
hex output, via qss or via `die.ini` file? I have manually change ini file
for color but it does not work!

**Disasm Output**:

I have changed the backgound of Disassembly output by adding those lines to qss:

```css
XDisasmView
{
    background-color:#073642;
    color: #fdf6e3;
    border: native;
}
```

Is this the intended way to change colors of disasm widget? Should I know
any other sub-controls or functions? (like hover or pressed)

**Entropy - Bytes Output**:

On entry tab there is a diagram and its graph color is red; how can I change that

On Bytes Tab there is a chart and its color is blue; how can I change that?

Best regards =)